### PR TITLE
Jump back to version 2c610026 for travis.yml but only for Puppet 4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 ---
 language: ruby
-#bundler_args: --without development
-cache: bundler
-rvm: 2.3.1
 script: "rake validate"
 matrix:
-  fast_finish: true
   include:
-  - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0"
-  - rvm: 2.1.5
-    env: PUPPET_VERSION="~> 3.8" FUTURE_PARSER="yes"
-  - rvm: 2.1.5
-    env: PUPPET_VERSION="~> 3.8"
+    - rvm: 2.3.1
+      env: PUPPET_VERSION=4.7.0
+    - rvm: 2.1.5
+      env: PUPPET_VERSION=3.8.6 FUTURE_PARSER=yes
+    - rvm: 2.1.5
+      env: PUPPET_VERSION=3.8.6

--- a/manifests/dhcp_config.pp
+++ b/manifests/dhcp_config.pp
@@ -45,7 +45,8 @@ define maas::dhcp_config (
   ## Maas Command to add a dhcp_config
   validate_re($cli_command, '(list-connected-macs|connect-macs|read|update|disconnect-macs|delete)$', 'Valid dhcp_config commands are "list-connected-macs","connect-macs","read","update","disconnect-macs","delete".')
   ## Login as Maas Superuser
-  notify{ "login-superuser-with-api-key-${maas::default_superuser}":} warning("Login to maas profile: ${maas::profile} with ${maas::default_superuser}") ->
+  notify { "login-superuser-with-api-key-${maas::default_superuser}": }
+  warning("Login to maas profile: ${maas::profile} with ${maas::default_superuser}")
   ## Generate Maas commandi argument for dhcp_config command
   case $cli_command {
     'list-connected-macs','read','delete': {

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -45,7 +45,8 @@ define maas::network (
   ## Maas Command to add a network
   validate_re($cli_command, '(list-connected-macs|connect-macs|read|update|disconnect-macs|delete)$', 'Valid network commands are "list-connected-macs","connect-macs","read","update","disconnect-macs","delete".')
   ## Login as Maas Superuser
-  notify{ "login-superuser-with-api-key-${maas::default_superuser}":} warning("Login to maas profile: ${maas::profile} with ${maas::default_superuser}") ->
+  notify{ "login-superuser-with-api-key-${maas::default_superuser}":}
+  warning("Login to maas profile: ${maas::profile} with ${maas::default_superuser}")
   ## Generate Maas command argument for network command
   case $cli_command {
     'list-connected-macs','read','delete': {

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -51,7 +51,8 @@ define maas::node (
   ## Maas Command to add a node
   validate_re($cli_command, '(start|stop|read|commission|update|details|release|delete)$', 'Valid node commands are "start","stop","read","update","details","release","delete".')
   ## Login as Maas Superuser
-  notify{ "login-superuser-with-api-key-${maas::maas_superuser}":} warning("Login to maas profile: ${maas::profile} with ${maas::maas_superuser}") ->
+  notify{ "login-superuser-with-api-key-${maas::maas_superuser}":}
+  warning("Login to maas profile: ${maas::profile} with ${maas::maas_superuser}")
   ## Generate Maas commandi argument for node command
   case $cli_command {
     'start','stop': {


### PR DESCRIPTION
Use matrix syntax.

https://docs.travis-ci.com/user/languages/ruby/

Fix tab issue.

Add rvm 2.1.5/puppet 3.8.6

Remove ordering arrow after warning. This is a syntax error in Puppet 3.